### PR TITLE
Track 2, Sardor Razikov, RepoMind

### DIFF
--- a/submissions/track2-sardorrazikov-repomind/PROJECT_SPEC.md
+++ b/submissions/track2-sardorrazikov-repomind/PROJECT_SPEC.md
@@ -1,0 +1,70 @@
+# RepoMind — Project Spec (Track 2, Agentic AI)
+
+## Background
+Two markets share one pain. **Path A — locked out:** regulated enterprises (finance, healthcare, defense,
+proprietary codebases) legally *cannot* send source code to a third-party LLM API, so cloud coding
+assistants are off-limits — on-prem is the only option. **Path B — bleeding:** teams that *can* use the
+cloud pay a fast-growing per-token bill. And separately, years of **CUDA** keep GPU teams locked to NVIDIA.
+
+RepoMind is the on-prem **cost + trust + migration layer** that answers all three — on AMD.
+
+## Target users & scenarios
+- Regulated enterprises needing a **private** coding assistant that never sends code off the box.
+- Teams wanting to **migrate CUDA workloads to AMD** (ROCm) without a painful manual port.
+- Developer-productivity / enterprise-copilot / local-knowledge-assistant (RAG) use cases.
+
+## System architecture (5 Track-2 capabilities)
+```
+Developer → RepoMind FastAPI
+              ├─ Agent loop:  plan → tool → observe → answer   (multi-step planning)
+              │     tools: list_files · grep_codebase · read_file · migrate_cuda_to_rocm  (tool-invocation)
+              ├─ RAG over the cloned repo                        (RAG)
+              ├─ Ed25519 tamper-evident audit trail             (multi-turn memory)
+              └─ cost-router → vLLM-ROCm on AMD Radeon/MI300X    (privacy / on-prem, AIR_GAP=0 egress)
+```
+
+## Models & algorithms
+| Component | Choice |
+|---|---|
+| Local coding model | Qwen2.5-Coder-14B-Instruct (open-weight), FP16 |
+| Serving | vLLM-ROCm 0.23 (OpenAI-compatible), continuous batching |
+| Agent | SC-TIR loop (plan/call/observe/answer), keyword+regex tool-arg parser |
+| CUDA→ROCm | deterministic rule engine (includes, memory/stream/event APIs, kernel-launch `<<<>>>`→`hipLaunchKernelGGL`) |
+
+## AMD Radeon GPU / ROCm adaptation
+- All inference runs locally on a **Radeon PRO W7900 (gfx1100, RDNA3, 48 GB)** via vLLM-ROCm / HIP (ROCm 7.2).
+- CUDA→ROCm output compiles with **hipcc** for `gfx1100` and **executes on the GPU** (verified, PASS).
+- `AIR_GAP=1` forces every token on-prem — measured `{"egress":"on-prem only (AIR_GAP)"}`.
+- Optimization: FP16 + vLLM continuous batching → **3.76×** aggregate throughput (measured).
+
+## Measured results (on the provided Radeon W7900)
+- Decode: **27.6 tok/s** single-stream → **103.8 tok/s** @ concurrency-4 (**3.76×**) → 106 @ conc-8.
+- TTFT **88 ms** · VRAM **46.8 GB**.
+- CUDA→ROCm compile-run: `vecAdd` **PASS** (kernel 0.71 ms) · `reduceSum` **PASS** (shared-mem + atomicAdd).
+- CUDA coverage: of the top-10 patterns, **9 have an AMD path** (5 auto-port; 4 → hipBLAS/MIOpen/rocThrust/
+  rocWMMA); only inline PTX is NVIDIA-only, and RepoMind flags it instead of faking a rename.
+
+## Reproduction
+```bash
+export HF_ENDPOINT=https://hf-mirror.com
+vllm serve Qwen/Qwen2.5-Coder-14B-Instruct --dtype float16 --max-model-len 32768 \
+  --gpu-memory-utilization 0.92 --host 0.0.0.0 --port 8000 \
+  --served-model-name qwen-coder --api-key token-repomind
+export AIR_GAP=1 VLLM_BASE_URL=http://localhost:8000 VLLM_MODEL=qwen-coder VLLM_API_KEY=token-repomind
+uvicorn main:app --host 0.0.0.0 --port 8090
+bash scripts/demo_final.sh          # agent + CUDA top-5 + honest boundary + bench
+python3 scripts/prove_and_benchmark.py   # CUDA→hipcc→RUN (PASS) + economics
+```
+
+## Demo video
+https://youtu.be/6YkKYjP_it0
+
+## Honesty note
+Throughput/tok-s/PASS are **measured** on the provided W7900. Cost comparisons vs cloud APIs are **modeled**
+from public prices and clearly labeled; on-prem's defensible edge is **privacy/air-gap**, not "cheapest".
+
+## Team
+Sardor Razikov (solo) — AMD Act I winner (AI Agents), AMD Featured Developer. GitHub @SRKRZ23.
+
+## References
+Project repo: https://github.com/SRKRZ23/repomind-amd-devmaster · Radeon deployment: `RADEON_CLOUD_DEPLOYMENT.md`.

--- a/submissions/track2-sardorrazikov-repomind/RADEON_CLOUD_DEPLOYMENT.md
+++ b/submissions/track2-sardorrazikov-repomind/RADEON_CLOUD_DEPLOYMENT.md
@@ -1,0 +1,50 @@
+# RepoMind — AMD Radeon Cloud Deployment
+
+How RepoMind was deployed and measured on the AMD Radeon Cloud instance during the hackathon.
+
+## Instance
+- GPU: **AMD Radeon PRO W7900** (gfx1100 / RDNA3, 48 GB).
+- Image: `vllm/vllm-openai-rocm:v0.23.0` · ROCm/HIP **7.2** · torch 2.10.
+- Access via the **JupyterLab browser terminal** (external SSH is blocked from outside CN).
+- Total compute used: **~2 hours (3 credits)** for the full Track-2 build + benchmarks.
+
+## 1. Serve the coding model (vLLM-ROCm, OpenAI-compatible)
+```bash
+export HF_ENDPOINT=https://hf-mirror.com          # HF is slow/blocked on the instance; use the mirror
+vllm serve Qwen/Qwen2.5-Coder-14B-Instruct \
+  --dtype float16 --max-model-len 32768 --gpu-memory-utilization 0.92 \
+  --host 0.0.0.0 --port 8000 --served-model-name qwen-coder --api-key token-repomind
+```
+Free shared Model APIs are also available on the portal; RepoMind is fully env-configurable
+(`VLLM_BASE_URL` / `VLLM_MODEL` / `VLLM_API_KEY`) so it can point at either.
+
+## 2. Start RepoMind (on-prem routing)
+```bash
+export AIR_GAP=1 VLLM_BASE_URL=http://localhost:8000 VLLM_MODEL=qwen-coder VLLM_API_KEY=token-repomind
+uvicorn main:app --host 0.0.0.0 --port 8090
+# health → {"status":"ok","egress":"on-prem only (AIR_GAP)"}
+```
+
+## 3. Run the demo + proofs
+```bash
+bash scripts/demo_final.sh              # GPU → health → agent → CUDA top-5 → honest boundary → bench
+python3 scripts/prove_and_benchmark.py  # CUDA → hipcc (gfx1100) → RUN on the GPU (PASS) + economics
+```
+
+## Gotchas we hit (documented so judges can reproduce)
+- **No CA certs** on the image → `git clone` fails with cert errors. Fix: `git config --global http.sslVerify false`.
+- **File upload** via JupyterLab lands in the current dir — move it to where the code runs (`/workspace/backend/`).
+- `rocm-smi --showproductname` throws libdrm errors in-container → use `rocminfo | grep "Marketing Name"`.
+- `hipcc` (/opt/rocm/bin) compiles the converted CUDA→HIP for gfx1100 without issue.
+
+## Measured optimization
+| config | throughput | note |
+|---|---|---|
+| fp16, single | 27.6 tok/s | baseline |
+| fp16, batched (conc-4) | **103.8 tok/s** | **3.76×** via vLLM continuous batching |
+| fp16, batched (conc-8) | 106.0 tok/s | W7900 saturation |
+TTFT 88 ms · VRAM 46.8 GB. Further headroom (not run): FP8/AWQ re-serve + larger KV budget.
+
+## Credit management
+One active instance, 1 credit / GPU-hour. Destroy the instance when idle — the whole submission (agent +
+CUDA→ROCm + benchmarks + video capture) fit in ~2 hours.

--- a/submissions/track2-sardorrazikov-repomind/README.md
+++ b/submissions/track2-sardorrazikov-repomind/README.md
@@ -1,0 +1,36 @@
+# RepoMind — On-Prem Agentic Coding Assistant + CUDA→ROCm (Track 2)
+
+**AMD AI DevMaster Hackathon · Track 2 — Agentic AI**
+**Team:** Sardor Razikov (solo) · GitHub [@SRKRZ23](https://github.com/SRKRZ23) · Tashkent, Uzbekistan
+**AMD Dev Program email:** razikovs777@gmail.com
+
+- 🎥 **Demo video:** https://youtu.be/6YkKYjP_it0
+- 📂 **Project repo (code + raw proofs + reproduce scripts):** https://github.com/SRKRZ23/repomind-amd-devmaster
+
+## One line
+An on-prem AI coding agent that plans, uses tools, reads your repository, and migrates **CUDA → ROCm** —
+running **100% on a single AMD Radeon PRO W7900** (ROCm), with **zero external egress** (`AIR_GAP`).
+
+## Track-2 capabilities (needs ≥2 of 5 — RepoMind does all 5)
+| Capability | How |
+|---|---|
+| RAG | clones + indexes the target repo, retrieves relevant files locally |
+| Tool-invocation | `list_files`, `grep_codebase`, `read_file`, `migrate_cuda_to_rocm` |
+| Multi-step planning | plan → tool → observe → answer loop (SC-TIR) |
+| Multi-turn memory | Ed25519 tamper-evident audit trail of every step |
+| Privacy / on-prem | `AIR_GAP=1` → all inference on the local Radeon, 0 egress |
+
+## Judging-criteria mapping
+- **Functional value (60):** agentic multi-step over a real repo (finds the exact file + fix) **+** a
+  CUDA→ROCm migrator (`/cuda-to-rocm`) that ports the top-5 patterns fully and flags the hard 10% with the
+  correct ROCm equivalent. Real CUDA → `hipcc` → **executed on the GPU, PASS**.
+- **ROCm / Radeon optimization (40):** local inference on the W7900 via vLLM-ROCm — **measured** 27.6 tok/s
+  single-stream → **103.8 tok/s (3.76×)** via continuous batching; TTFT 88 ms; 46.8 GB VRAM.
+
+## Deliverables
+- FastAPI agent + cost-router + CUDA→ROCm migrator (source in the project repo, `backend/`).
+- Reproduce scripts: `demo_final.sh`, `prove_and_benchmark.py`, `cuda_top5.py`, `cuda_hard_cases.py`.
+- Raw proofs: compiled HIP binaries, `.hip.cpp`, benchmark logs, SHA-256 sums, environment snapshot.
+
+See `PROJECT_SPEC.md` (full spec) and `RADEON_CLOUD_DEPLOYMENT.md` (how it runs on Radeon).
+Every number labeled **measured** is reproducible on the provided Radeon Cloud W7900.


### PR DESCRIPTION
Track 2 (Agentic AI) — RepoMind: on-prem agentic coding assistant + CUDA to ROCm, 100% on AMD Radeon.

Demo video: https://youtu.be/6YkKYjP_it0
Project repo: https://github.com/SRKRZ23/repomind-amd-devmaster
Submission: submissions/track2-sardorrazikov-repomind/ (README, PROJECT_SPEC, RADEON_CLOUD_DEPLOYMENT)

Functional-60: agentic multi-step over a real repo (finds the exact file + fix) + CUDA to ROCm (real CUDA compiled with hipcc and executed on the GPU — PASS).
ROCm-40: measured on W7900 — 27.6 to 103.8 tok/s (3.76x via batching), TTFT 88 ms.

Solo — Sardor Razikov (@SRKRZ23), AMD Dev Program razikovs777@gmail.com.